### PR TITLE
fix: 修复用例列表中,编辑用例/任务后,会跳回默认列表的问题

### DIFF
--- a/case-server/src/main/resources/web/src/components/case/caselist/index.js
+++ b/case-server/src/main/resources/web/src/components/case/caselist/index.js
@@ -52,6 +52,7 @@ class CaseLists extends React.Component {
       isReName: true,
       treeSelect: [],
       treeData: [],
+      expendKeys: [] // 控制用例列表中处于展开状态的行
     };
   }
   componentDidMount() {
@@ -332,6 +333,7 @@ class CaseLists extends React.Component {
               createrFilter={createrFilter}
               iterationFilter={iterationFilter}
               choiseDate={choiseDate}
+              expendKeys={this.state.expendKeys}
             ></List>
 
             {(this.props.type === 'oe' && filterVisble && (
@@ -362,9 +364,13 @@ class CaseLists extends React.Component {
               doneApiPrefix={this.props.doneApiPrefix}
               baseUrl={this.props.baseUrl}
               onUpdate={() => {
-                // this.getCaseList(this.state.current || 1, '', '', '', []);
-                this.getTreeList();
-                this.setState({ currCase: null, visible: false });
+                this.setState({ 
+                  currCase: null, 
+                  visible: false, 
+                  expendKeys: [] // 强制把处于展开状态的行变为无
+                });
+                // 更新完成后回到原页面
+                this.getCaseList(this.state.current || 1, '', '', '', []);
               }}
               type={this.props.type}
               caseIds={caseIds}

--- a/case-server/src/main/resources/web/src/components/case/caselist/list.js
+++ b/case-server/src/main/resources/web/src/components/case/caselist/list.js
@@ -46,7 +46,7 @@ class Lists extends React.Component {
       taskVisible: false,
       record: null,
       extRecord: null,
-      expendKeys: [],
+      expendKeys: this.props.expendKeys,
       titleModeTask: '',
       loading: this.props.loading,
       extendLoading: new Map(),
@@ -71,6 +71,7 @@ class Lists extends React.Component {
           iterationFilter: this.props.iterationFilter,
           createrFilter: this.props.createrFilter,
           nameFilter: this.props.nameFilter,
+          expendKeys: nextProps.expendKeys,
         });
       });
     }


### PR DESCRIPTION
对应问题：https://github.com/didi/AgileTC/issues/45

因不确定何时会合并，为避免冲突，提交中不包含编译后文件。需要合并后帮忙更新下编译后文件。